### PR TITLE
feat: derive Cclone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use std::option::Option;
 type Slice = (usize, usize);
 
 /// Represents a single dictionary entry in the CC-CEDICT format.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct DictEntry<T> {
     line: T,
     traditional: Slice,


### PR DESCRIPTION
Deriving these common traits would make it easier for me to use `cedict`.